### PR TITLE
🎨 Palette: Improve CLI Output Formatting

### DIFF
--- a/supremo_rpg_final.py
+++ b/supremo_rpg_final.py
@@ -96,6 +96,13 @@ def frase_log(entidade, acao, sucesso=True, cor="\u001B[92m"):
     cargo = entidade.cargo if hasattr(entidade, 'cargo') else 'Sistema'
     return f"{cor}[{nome}-{cargo}] {acao} - {status}\u001B[0m"
 
+def exibir_dict_formatado(titulo: str, dados: Dict[str, Any]):
+    """Exibe um dicionário com formatação e cores para melhor UX."""
+    print(f"\n\u001B[95m--- {titulo.upper()} ---\u001B[0m")
+    max_len = max(len(k) for k in dados.keys()) if dados else 0
+    for chave, valor in dados.items():
+        print(f"  \u001B[96m{chave.ljust(max_len)}\u001B[0m : \u001B[93m{valor}\u001B[0m")
+
 # 3. --- OBJETOS DO JOGO (RPG CORE) ---
 class Personagem:
     """Representa uma Unidade, NPC ou Jogador (Base de RPG)."""
@@ -378,9 +385,8 @@ if __name__ == "__main__":
     agente_inativo = Personagem("Inativo", cargo="Jogador")
     storage.logins[agente_inativo.id] = datetime.now() - timedelta(days=31)
 
-    print("\n--- STATUS DE HIERARQUIA E BASE ---")
-    print(base.status())
-    print(proprietario.ficha())
+    exibir_dict_formatado("Status da Base", base.status())
+    exibir_dict_formatado(f"Ficha de {proprietario.nome}", proprietario.ficha())
 
     # 2. CICLO TECNOLOGIA E COMPORTAMENTO
     print("\n--- CICLO: TECNOLOGIA E COMPORTAMENTO ---")


### PR DESCRIPTION
* 💡 **What**: Added a new helper function, `exibir_dict_formatado`, to format dictionary output in the terminal with colors and proper alignment.
* 🎯 **Why**: The previous implementation printed raw dictionaries to the console, which was difficult to read. This change makes the status information much clearer and more pleasant to view.
* 📸 **Before/After**:
    *   **Before**: The script printed raw Python dictionaries like `{'Base': 'Bastião da Verdade', 'Comandante': 'Caíque', ...}`.
    *   **After**: The script now displays this information in a formatted, table-like structure with color-coded keys and values.
* ♿ **Accessibility**: While not a traditional GUI, this change improves readability for all users viewing the terminal output, which is a form of accessibility.

---
*PR created automatically by Jules for task [6927437909053076534](https://jules.google.com/task/6927437909053076534) started by @trapaceirojogo040-cmd*